### PR TITLE
Implement experimental support for coroutines

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
     // Use the Kotlin JDK 8 standard library.
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
+    // Use Kotlin coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+
     // Use the Kotlin test library.
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 

--- a/lib/src/main/kotlin/io/nexure/fsm/Action.kt
+++ b/lib/src/main/kotlin/io/nexure/fsm/Action.kt
@@ -1,5 +1,5 @@
 package io.nexure.fsm
 
 interface Action<N : Any> {
-    fun action(signal: N)
+    suspend fun action(signal: N)
 }

--- a/lib/src/main/kotlin/io/nexure/fsm/Coroutines.kt
+++ b/lib/src/main/kotlin/io/nexure/fsm/Coroutines.kt
@@ -1,0 +1,6 @@
+package io.nexure.fsm
+
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.runBlocking
+
+internal fun <T> Deferred<T>.awaitBlocking() = runBlocking { this@awaitBlocking.await() }

--- a/lib/src/main/kotlin/io/nexure/fsm/Edge.kt
+++ b/lib/src/main/kotlin/io/nexure/fsm/Edge.kt
@@ -7,7 +7,7 @@ internal class Edge<S : Any, E : Any, N : Any>(
     val source: S,
     val target: S,
     val event: E,
-    val action: (N) -> Unit
+    val action: suspend (N) -> Unit
 ) {
     operator fun component1(): S = source
     operator fun component2(): S = target

--- a/lib/src/main/kotlin/io/nexure/fsm/StateMachine.kt
+++ b/lib/src/main/kotlin/io/nexure/fsm/StateMachine.kt
@@ -1,5 +1,7 @@
 package io.nexure.fsm
 
+import kotlinx.coroutines.Deferred
+
 /**
  * S = State
  * E = Event triggering a transition between two states
@@ -29,13 +31,13 @@ interface StateMachine<S : Any, E : Any, N : Any> {
     /**
      * Execute a transition from [state] to another state depending on [event].
      * If an action is associated with the state transition, it will then be executed,
-     * with [signal] as input. Returns a [Transition] indicating if the transition was permitted and
+     * with [signal] as input. Returns a Deferred [Transition] indicating if the transition was permitted and
      * successful or not.
      *
      * It is recommended that the return value is checked for the desired outcome, if it is critical
      * that an event for example is accepted and not rejected.
      */
-    fun onEvent(state: S, event: E, signal: N): Transition<S>
+    fun onEvent(state: S, event: E, signal: N): Deferred<Transition<S>>
 
     companion object {
         fun <S : Any, E : Any, N : Any> builder(): StateMachineBuilder<S, E, N> = StateMachineBuilder()

--- a/lib/src/test/kotlin/io/nexure/fsm/ExampleStateMachine.kt
+++ b/lib/src/test/kotlin/io/nexure/fsm/ExampleStateMachine.kt
@@ -53,15 +53,15 @@ fun callExampleStateMachine(fsm: StateMachine<PaymentState, PaymentEvent, Paymen
     val payment = PaymentData("foo", 42)
 
     // Transition from state CREATED into state PENDING
-    val state1 = fsm.onEvent(PaymentState.Created, PaymentEvent.PaymentSubmitted, payment)
+    val state1 = fsm.onEvent(PaymentState.Created, PaymentEvent.PaymentSubmitted, payment).awaitBlocking()
     assertEquals(Executed(PaymentState.Pending), state1)
 
     // Transition from state PENDING into state AUTHORIZED
-    val state2 = fsm.onEvent(PaymentState.Pending, PaymentEvent.BankAuthorization, payment)
+    val state2 = fsm.onEvent(PaymentState.Pending, PaymentEvent.BankAuthorization, payment).awaitBlocking()
     assertEquals(Executed(PaymentState.Authorized), state2)
 
     // Transition from state AUTHORIZED into state SETTLED
-    val state3 = fsm.onEvent(PaymentState.Authorized, PaymentEvent.FundsMoved, payment)
+    val state3 = fsm.onEvent(PaymentState.Authorized, PaymentEvent.FundsMoved, payment).awaitBlocking()
     assertEquals(Executed(PaymentState.Settled), state3)
 }
 


### PR DESCRIPTION
This implements support for coroutines, or more specifically, actions that are executed on state changes are now suspend functions rather than regular functions, as requested by @aktersnurra.

The downside with this change is that the API gets a bit messier (and has a lot of breaking changes). Especially, the onEvent method signature changed
- From: `fun onEvent(state: S, event: E, signal: N): Transition<S>`
- To: `fun onEvent(state: S, event: E, signal: N): Deferred<Transition<S>>`

which means that to get the outcome of a transition attempt, one would have to call `.await()` on the returned value. This implies that the method is called in a suspend function or within a coroutine context.

Some alternative solutions that may be worth considering are:
1. Keep onEvent as is, and execute suspend functions with runBlocking under the hood and then add a new method the interface that is onEventAsync which returns a Deferred<Transition<T>>. The downside with this is that by default, all suspend function will be run within a `runBlocking { ... }` block, but there will be no breaking API changes.
2. Make onEvent a suspend function (cleaner API, but more complicated if onEvent is to be called in a non-suspending function) - see #5 for example of this
3. Create a separate state machine API and implementation only for supporting coroutines, while keeping the existing one as-is.
4. Just like option 1, we don't change the signature of onEvent, and we execute suspend functions in a runBlocking context. But in addition to this we add a new method to the interface which permits execution of suspend method (`onEventAsync` or similar) without blocking.

I will not merge this PR in the immediate future, since I don't think it is - yet - obvious what the best solution is, or if this is even a change we should go with long term, but I think we could perhaps make an experimental release that can be tested out if needed.