### PR TITLE
feat: create country state machine config

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
 
+    implementation("com.neovisionaries:nv-i18n:1.29")
+
     // Use the Kotlin JUnit integration.
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 }

--- a/lib/src/main/kotlin/io/nexure/fsm/CountryStateMachineInterfaces.kt
+++ b/lib/src/main/kotlin/io/nexure/fsm/CountryStateMachineInterfaces.kt
@@ -17,5 +17,4 @@ interface CountryEdge<S : Any, E : Any> {
 
 interface CountryStateMachineFactory<S : Any, E : Any, C : CountryStateMachineConfig<S, E>> {
     suspend fun createFsmForAllCountries(): MutableMap<CountryCode, StateMachine<S, E>>
-    fun createStateMachineForCountry(transitions: List<CountryEdge<S, E>>): StateMachine<S, E>?
 }

--- a/lib/src/main/kotlin/io/nexure/fsm/CountryStateMachineInterfaces.kt
+++ b/lib/src/main/kotlin/io/nexure/fsm/CountryStateMachineInterfaces.kt
@@ -6,6 +6,7 @@ interface CountryStateMachineConfig<S : Any, E : Any> {
     val country: CountryCode
     val enabled: Boolean
     val transitions: List<CountryEdge<S, E>>
+    val initialState: S
 }
 
 interface CountryEdge<S : Any, E : Any> {

--- a/lib/src/main/kotlin/io/nexure/fsm/CountryStateMachineInterfaces.kt
+++ b/lib/src/main/kotlin/io/nexure/fsm/CountryStateMachineInterfaces.kt
@@ -1,4 +1,20 @@
 package io.nexure.fsm
 
-class CountryStateMachineInterfaces {
+import com.neovisionaries.i18n.CountryCode
+
+interface CountryStateMachineConfig<S : Any, E : Any> {
+    val country: CountryCode
+    val enabled: Boolean
+    val transitions: List<CountryEdge<S, E>>
+}
+
+interface CountryEdge<S : Any, E : Any> {
+    val source: S
+    val target: S
+    val event: E
+}
+
+interface CountryStateMachineFactory<S : Any, E : Any, C : CountryStateMachineConfig<S, E>> {
+    suspend fun createFsmForAllCountries(): MutableMap<CountryCode, StateMachine<S, E>>
+    fun createStateMachineForCountry(transitions: List<CountryEdge<S, E>>): StateMachine<S, E>?
 }

--- a/lib/src/main/kotlin/io/nexure/fsm/CountryStateMachineInterfaces.kt
+++ b/lib/src/main/kotlin/io/nexure/fsm/CountryStateMachineInterfaces.kt
@@ -1,0 +1,4 @@
+package io.nexure.fsm
+
+class CountryStateMachineInterfaces {
+}


### PR DESCRIPTION
creating a country state machine to be implemented by services to be able to determine fsm depending on a country